### PR TITLE
ADD: New workflow for heroku deployment

### DIFF
--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to Heroku
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
+
+      - name: Authenticate with Heroku
+        run: |
+          echo "$HEROKU_API_KEY" | heroku auth:token
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+
+      - name: Deploy to Heroku
+        run: |
+          heroku git:remote -a $HEROKU_APP_NAME
+          git push heroku main
+        env:
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+          HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}


### PR DESCRIPTION
I've added new github secrets for my Heroku API key, our app name, and my email for my account. 

This new workflow should automatically install heroku cli, authenticate, and deploy to our app on all pushes to 'main' branch. 