### PR TITLE
WIP tasks now have cooldowns that are managed in game_logic_channel. …

### DIFF
--- a/app/assets/javascripts/channels/game_logic_channel.js
+++ b/app/assets/javascripts/channels/game_logic_channel.js
@@ -167,6 +167,10 @@ const handleGameChannelEvent = (data, userId, lastPosition) => {
             showFlashMessage(data.message || "Invalid move.", "alert");
             break;
 
+        case "task_unavailable":
+            showFlashMessage(data.message, "alert"); // Display the cooldown flash message
+            break;
+
         case "error":
             showFlashMessage(data.message || "An error occurred.", 'alert');
             break;

--- a/app/assets/javascripts/game_ui.js
+++ b/app/assets/javascripts/game_ui.js
@@ -9,6 +9,7 @@ document.addEventListener("turbolinks:load", () => {
         return;
     }
 
+
     cells.forEach(cell => {
         // Add new listeners without replacing the node
         cell.addEventListener("mouseover", () => {


### PR DESCRIPTION
…Users must wait 30 seconds to redo a task. They now get error messages when they try to repeat a task too quickly

### Description
<!-- Briefly describe what this PR does and why it's needed -->
Added cooldowns to tasks 

### Related Issues
<!-- List any related issues or tasks, add the issue number or title -->
- Resolves #[127]

### Changes Made
<!-- Provide a list of what was added, changed, or fixed -->
1. when grid is pressed a timestamp of the task is saved
2. if it has been less than 30 seconds since the task was entered the user must wait 
3. added flash message if user needs to wait 

### Testing
<!-- Describe the testing steps or provide a checklist -->
- [ x] Feature tested locally
- [ ] Added unit tests (if applicable)
- [ x] Passes CI/CD checks

### Screenshots (if applicable)
<!-- Add screenshots here if needed -->

### Checklist
- [ x] I have performed a self-review of my code.
- [ ] I have added comments where necessary.
- [ ] I have updated the documentation (if applicable).
- [ x] I have ensured my changes do not break existing functionality.

### Additional Notes
<!-- Include any additional information or future considerations -->
